### PR TITLE
Updating the README with more descriptive detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,46 @@
 
 Meeting notes from the [O3DE Meetings](https://o3de.github.io/sig-core/meetings/).
 
-The [full table of previous meetings](https://o3de.github.io/sig-core/meetings?id=previous-meetings) is available here.
+
 
 # General Resources
+
+# Open 3D Engine Special Interest Group for Core Systems (SIG Core)
+
+This repository holds materials for the Open 3D Engine Foundation Special Interest Group for Core Systems (SIG-Core).
+
+## Description of SIG Core
+We manage the Core Systems needed by O3DE libraries to fulfill the engines requirements. Primarily low-level systems such as memory management, application startup and file input/output are implemented by. See the [SIG's charter](governance/SIG%20Core%20Charter.md) for full details.
+
+## What the SIG does:
+
+* Contributes to changes to O3DE Core Systems in library(AzCore/AzFramework/AzToolsFramework/AzGameFramework).  
+* Collaborate with SIG-Simulation for changes to the Math library and Tick System. 
+* Collaborate with SIG-Platform for implementation of low level systems(memory management, keyboard/mouse input, file input/output, etc...).  
+* Maintains the Gem System and integrations with CMake.  
+* Maintains the Unified Game Launcher.  
+* Maintains the AZStd C++ standard library layer
+* Implements Core features such as the memory management system, reflection system, archive system, virtual filesystem layer, settings registry, etc...  
+* Provides support to community for core system topics.  
+* Works with other SIGs and the TSC on core systems issues.  
+* Publish and maintain [standards and best practices](https://github.com/o3de/sig-core/tree/main/governance).  
+
+## How do I get involved?
+
+* Contact us on [Discord](https://discord.com/invite/o3de). The SIG has a specific chat channel **#sig-core**.
+* Attend any of our public meetings by connecting to the **#sig-core** voice channel on O3DE's Discord server. See the [O3DE Calendar](https://lists.o3de.org/g/o3de-calendar/calendar) for upcoming meetings and details.
+    * SIG-Core hosts a general meeting once a month, to discuss the core systems features, recently contributed work, pending RFCs, and other items of interest to SIG-Core. Look for the meeting titled **SIG-Core Meeting** on O3DE calendar. [Meeting agendas](issues?q=is%3Aissue+is%3Aopen+label%3Amtg-agenda) are posted in advanced as GitHub issues and anyone can raise issues for discussion.
+    * The SIG also meets once per week, on Wednesday at 9:00am PST/PDT(16:00 UTC from 2nd week of March - 1st week of November, 17:00 UTC from 2nd week of November - 1st week of March), to review any new issues of interest to the SIG. Look for the meeting titled **SIG-Core Issue Triage** and see the [Triage Guide](TRIAGE_GUIDE.md) for more details of what happens at this meeting.
+* Subscribe to the [SIG-Core mailing list](https://lists.o3de.org/g/sig-core), which is used to send out information on the next monthly meeting as well as the meeting agenda.
+
+### Who can attend or participate?
+O3DE cannot work without the help and input from as many of its community members as possible. You do not need anyone’s permission to get involved and contribute to the project. The #sig-core channel on O3DE Discord is a great place to begin getting involved. Many of our community members regularly share ideas, updates, and resources there. You can also find a number of topics under the GitHub Discussions area which need your input.
+
+## Helpful information
+
+* SIG Chair: AMZN-Pratik [Amazon, [@amzn-pratikpa](https://github.com/amzn-pratikpa)], Co-chair: geds-dm [Amazon, [@lumberyard-employee-dm](https://github.com/lumberyard-employee-dm)]
+* [SIG-Core Charter](governance/SIG%20Core%20Charter.md)
+* [Open Issues](issues?q=is%3Aissue+is%3Aopen+label%3Amtg-agenda)
+* [Full table of previous meetings](meetings?id=previous-meetings) is available here.
+
+Some of this guide was influenced by the [SIG-Network Readme](https://github.com/o3de/sig-network/blob/main/README.md). Thanks to the contributors there.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ We manage the Core Systems needed by O3DE and its libraries to fulfill the engin
 
 ## What the SIG does:
 
-* Contributes to changes to O3DE Core Systems in library(AzCore/AzFramework/AzToolsFramework/AzGameFramework).  
+* Contributes changes to O3DE Core Systems in the libraries of AzCore, AzFramework, AzToolsFramework, etc...  
 * Collaborate with SIG-Simulation for changes to the Math library and Tick System. 
 * Collaborate with SIG-Platform for implementation of low level systems(memory management, keyboard/mouse input, file input/output, etc...).  
 * Maintains the Gem System and integrations with CMake.  

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Meeting notes from the [O3DE Meetings](https://o3de.github.io/sig-core/meetings/
 This repository holds materials for the Open 3D Engine Foundation Special Interest Group for Core Systems (SIG-Core).
 
 ## Description of SIG Core
-We manage the Core Systems needed by O3DE libraries to fulfill the engines requirements. Primarily low-level systems such as memory management, application startup and file input/output are implemented by. See the [SIG's charter](governance/SIG%20Core%20Charter.md) for full details.
+We manage the Core Systems needed by O3DE and its libraries to fulfill the engines requirements. The SIG primarily owns low-level systems such as memory management, application startup and file input/output. See the [SIG's charter](governance/SIG%20Core%20Charter.md) for full details.
 
 ## What the SIG does:
 


### PR DESCRIPTION
Added information about the responsibilities of the SIG-Core group.
Added links to the list of Open issues for the SIG-Core group, a link to the charter, as well information about the Chair and Co-Chair.

Furthermore information about how to contact the SIG-Core group, as well as the time of triage sessions take place have been added.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>