### PR TITLE
Updated SIG Core Character with SIG-Governance links

### DIFF
--- a/governance/SIG Core Charter.md
+++ b/governance/SIG Core Charter.md
@@ -66,26 +66,26 @@ Two concise lines explaining what this SIG does with bullet points of the major 
 
 # Roles and Organization Management 
 
-SIG-Core adheres to the standards for roles and organization management as specified by <sig-governance>. This SIG opts in to updates and modifications to <sig-governance>
+SIG-Core adheres to the standards for roles and organization management as specified by [SIG-Governance](https://github.com/o3de/community/tree/main/sigs). This SIG opts in to updates and modifications to [SIG-Governance](https://github.com/o3de/community/tree/main/sigs)
 
 ## Individual Contributors 
 Must provide a report of performance and blast radius impact of direct and indirectly affected systems
 
-Additional information not found in the sig-governance related to contributors.
+Additional information not found in the [sig-governance](https://github.com/o3de/community/tree/main/sigs) related to contributors.
 
 ## Maintainers 
  
-Additional information not found in the sig-governance related to contributors
+Additional information not found in the [sig-governance](https://github.com/o3de/community/tree/main/sigs) related to contributors
 
 ## Additional responsibilities of Chairs 
 
-Additional information not found in the sig-governance related to SIG Chairs
+Additional information not found in the [sig-governance](https://github.com/o3de/community/tree/main/sigs) related to SIG Chairs
 
 ## Subproject Creation 
 
-Additional information not found in the sig-governance related to subproject creation
+Additional information not found in the [sig-governance](https://github.com/o3de/community/tree/main/sigs) related to subproject creation
 
-## Deviations from sig-governance 
+## Deviations from [sig-governance](https://github.com/o3de/community/tree/main/sigs) 
 None
 
-## Explicit Deviations from the sig-governance 
+## Explicit Deviations from the [sig-governance](https://github.com/o3de/community/tree/main/sigs) 

--- a/governance/SIG Core Charter.md
+++ b/governance/SIG Core Charter.md
@@ -1,19 +1,22 @@
 # SIG Core Charter 
 
-This charter adheres to the Roles and Organization Management specified in "<sig-governance.md>".
+This charter adheres to the Roles and Organization Management specified in "[sig-governance.md](https://github.com/o3de/community/tree/main/sigs)".
 
-Team information may be found in the "<readme.md>"
+Team information may be found in the "[README.md](https://github.com/o3de/sig-core/blob/main/README.md)"
 
 # Overview of SIG #
 
 Two concise lines explaining what this SIG does with bullet points of the major responsibilities
 
-- Responsibility 1
+- Maintains and updates Core O3DE Systems: Gem (Plugin System), Serialization, Engine Initialization and Configuration, Settings,
+- Provides Memory Allocator Framework and Metrics Logging system
 
 # Goals #
 
-
-- Major goals that SIG seeks to generally achieve
+- Extend the Gem (Modular Framework) plugin system which allows developers to easily add libraries/applications into O3DE
+- Reduce Developer Iteration Time through better organization of code through the Gem and Project Templates
+   - Provide framework via the o3de template system as well as guidance on to properly separate public API vs private implementation to help reduce build times
+ - Gather performance metrics on Core Applications' startup to come with a strategy to improve runtime performance(Reduce launch time to enter Editor, reduce assets loading time)
 
 # Scope 
 


### PR DESCRIPTION
The SIG Core charter would link to the Community repo SIG page with information about general O3DE Governance that all SIGs follow